### PR TITLE
added 404 template

### DIFF
--- a/templates/404.hbs
+++ b/templates/404.hbs
@@ -1,0 +1,9 @@
+<html>
+    <head>
+        <title>Not Found</title>
+    </head>
+    <body>
+        <h1>Not Found</h1>
+        <p>The requested resource was not found.</p>
+    </body>
+</html>


### PR DESCRIPTION
Hello Techfund!

During the course of getting up and running i noticed that the handlebars template `templates/404.hbs` is referenced, but it does not actually exist in the repo. This PR adds the file. I might have misunderstood something though, perhaps Hiwrite is intended to be used from within another directory somehow? 